### PR TITLE
Adding a "Contribute" search scope

### DIFF
--- a/Contribute/docfx.json
+++ b/Contribute/docfx.json
@@ -37,6 +37,8 @@
       "breadcrumb_path": "~/breadcrumb/toc.yml",
       "extendBreadcrumb": true,
       "titleSuffix": "Contributor Guide",
+      "searchScope": ["Contribute"],
+      "hideScope": true,
       "feedback_system": "GitHub",
       "feedback_github_repo": "MicrosoftDocs/Contribute",
       "feedback_product_url": "https://aka.ms/sitefeedback"


### PR DESCRIPTION
Also including hideScope, because once you turn on scope it is used in searches *but* the index doesn't know about a new scope for a day or so... so all the searches return zero results. Ideal technique is to turn on a scope, make it live but hidden, then go back and remove hideScope after 24-48 hours (after results are working with the Contribute scope).