### PR TITLE
turn off PR comments

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -21,6 +21,7 @@
   "branches_to_filter": [],
   "skip_source_output_uploading": false,
   "need_preview_pull_request": true,
+  "need_pr_comments": false,
   "contribution_branch_mappings": {},
   "dependent_repositories": [
     {


### PR DESCRIPTION
It's much more useful to see only the most recent build status on a PR than seeing the history of all messages from all builds on the PR.

/cc @DuncanmaMSFT 