### PR TITLE
change default metadata

### DIFF
--- a/Contribute/additional-resources.md
+++ b/Contribute/additional-resources.md
@@ -4,10 +4,6 @@ description: This article lists suggested resources for Git and GitHub learning 
 author: billwagner
 ms.author: wiwagn
 manager: wpickett
-ms.date: 02/27/2018
-ms.prod: non-product-specific
-ms.topic: contributor-guide
-ms.custom: external-contributor-guide
 ---
 # Additional Git and Github resources
 

--- a/Contribute/docfx.json
+++ b/Contribute/docfx.json
@@ -41,8 +41,14 @@
       "hideScope": true,
       "feedback_system": "GitHub",
       "feedback_github_repo": "MicrosoftDocs/Contribute",
-      "feedback_product_url": "https://aka.ms/sitefeedback"
-    },
+      "feedback_product_url": "https://aka.ms/sitefeedback",
+      "author": "billwagner",
+      "ms.author": "wiwagn",
+      "manager": "wpickett",
+      "ms.prod": "non-product-specific",
+      "ms.topic": "contributor-guide",
+      "ms.custom": "external-contributor-guide"
+          },
     "fileMetadata": {},
     "template": [],
     "dest": "ContributionGuide"

--- a/Contribute/get-started-setup-github.md
+++ b/Contribute/get-started-setup-github.md
@@ -1,13 +1,7 @@
 ---
 title: GitHub account setup steps
 description: This article steps you through the process of setting up accounts for GitHub, required in order to contribute to docs.microsoft.com content.
-author: bryanla
-ms.author: bryanla
-manager: mbaldwin
 ms.date: 02/27/2018
-ms.prod: non-product-specific
-ms.topic: contributor-guide
-ms.custom: external-contributor-guide
 ---
 # GitHub account setup
 

--- a/Contribute/get-started-setup-local.md
+++ b/Contribute/get-started-setup-local.md
@@ -5,9 +5,6 @@ author: jasonwhowell
 ms.author: jasonh
 manager: kfile
 ms.date: 01/18/2018
-ms.prod: non-product-specific
-ms.topic: contributor-guide
-ms.custom: external-contributor-guide
 ---
 # Set up Git repository locally for documentation
 

--- a/Contribute/get-started-setup-tools.md
+++ b/Contribute/get-started-setup-tools.md
@@ -5,9 +5,6 @@ author: jasonwhowell
 ms.author: jasonh
 manager: kfile
 ms.date: 04/30/2018
-ms.prod: non-product-specific
-ms.topic: contributor-guide
-ms.custom: external-contributor-guide
 ---
 # Install content authoring tools
 

--- a/Contribute/git-github-fundamentals.md
+++ b/Contribute/git-github-fundamentals.md
@@ -1,13 +1,7 @@
 ---
 title: Git and GitHub essentials for Documentation
 description: This article explains an overview of Git,  GitHub repository, and how content is organized, and naming conventions used for docs.microsoft.com.
-author: bryanla
-ms.author: bryanla
-manager: mbaldwin
 ms.date: 06/30/2017
-ms.prod: non-product-specific
-ms.topic: contributor-guide
-ms.custom: external-contributor-guide
 ---
 # Git and GitHub essentials for Docs
 

--- a/Contribute/how-to-write-docs-auth-pack.md
+++ b/Contribute/how-to-write-docs-auth-pack.md
@@ -5,9 +5,6 @@ author: meganbradley
 ms.author: mbradley
 manager: jemash
 ms.date: 04/06/2018
-ms.prod: non-product-specific
-ms.topic: contributor-guide
-ms.custom: external-contributor-guide
 ---
 # Docs Authoring Pack for VS Code
 

--- a/Contribute/how-to-write-links.md
+++ b/Contribute/how-to-write-links.md
@@ -1,13 +1,7 @@
 ---
 title: How to use links in documentation
 description: This article provides guidance on creating links to content within docs.microsoft.com.
-author: bryanla
-ms.author: bryanla
-manager: mbaldwin
 ms.date: 06/29/2017
-ms.prod: non-product-specific
-ms.topic: contributor-guide
-ms.custom: external-contributor-guide
 ---
 # Using links in documentation
 This article describes how to use hyperlinks from pages hosted at docs.microsoft.com. Links are easy to add into markdown with a few varying conventions. Links point users to content in the same page, point off into other neighboring pages, or point to external sites and URLs.

--- a/Contribute/how-to-write-use-markdown.md
+++ b/Contribute/how-to-write-use-markdown.md
@@ -1,13 +1,7 @@
 ---
 title: How to use Markdown for writing Docs
 description: This article provides the basics and reference information for the Markdown language used for writing docs.microsoft.com articles.
-author: bryanla
-ms.author: bryanla
-manager: mbaldwin
 ms.date: 07/13/2017
-ms.prod: non-product-specific
-ms.topic: contributor-guide
-ms.custom: external-contributor-guide
 ---
 # How to use Markdown for writing Docs
 

--- a/Contribute/how-to-write-workflows-major.md
+++ b/Contribute/how-to-write-workflows-major.md
@@ -1,13 +1,7 @@
 ---
 title: GitHub contribution workflow for major or long-running changes
 description: This article shows you how to use the "major" contributor workflow to make contributions to docs.microsoft.com articles.
-author: bryanla
-ms.author: bryanla
-manager: mbaldwin
 ms.date: 08/30/2017
-ms.prod: non-product-specific
-ms.topic: contributor-guide
-ms.custom: external-contributor-guide
 ---
 # GitHub contribution workflow for major or long-running changes
 

--- a/Contribute/index.md
+++ b/Contribute/index.md
@@ -1,13 +1,10 @@
 ---
 title: Microsoft Docs contributor guide overview
 description: The guide describes how you can contribute to the Microsoft documentation site docs.microsoft.com.
-author: bryanla
-ms.author: bryanla
-manager: mbaldwin
+author: billwagner
+ms.author: wiwagn
+manager: wpickett
 ms.date: 04/17/2018
-ms.prod: non-product-specific
-ms.topic: contributor-guide
-ms.custom: external-contributor-guide
 ---
 
 # Microsoft Docs contributor guide overview

--- a/Contribute/style-quick-start.md
+++ b/Contribute/style-quick-start.md
@@ -1,13 +1,7 @@
 ---
 title: Docs Style guide - Quick start
 description: This article is a concise guide for style considerations, containing just the essential topics for getting started with docs.microsoft.com.
-author: bryanla
-ms.author: bryanla
-manager: mbaldwin
 ms.date: 07/25/2017
-ms.prod: non-product-specific
-ms.topic: contributor-guide
-ms.custom: external-contributor-guide
 ---
 # Docs style and voice quick start
 


### PR DESCRIPTION
This PR does the following:

1. add defaults in docfx.json for the following metadata: ms.prod, ms.technology, ms.custom,  author, ms.author, and manager.
2. Remove those items from *.md where the defaults are correct.

A future PR may change the defaults to a bot and an alias. Therefore, articles that did not have the old values for author or ms.author were not changed.

/cc @MonicaRush, @jasonh,  @mbradley, @BryanLa 