### PR TITLE
Expand git instructions for Mac and Linux

### DIFF
--- a/Contribute/get-started-setup-tools.md
+++ b/Contribute/get-started-setup-tools.md
@@ -10,7 +10,7 @@ ms.date: 04/30/2018
 
 This article describes the steps to interactively install Git client tools and Visual Studio Code.
 > [!div class="checklist"]
-> * Install [Git for Windows](https://git-scm.com/download/win)
+> * Install [Git](https://git-scm.com/)
 > * Install [Visual Studio Code](https://code.visualstudio.com/)
 > * Install [Docs Authoring Pack](https://marketplace.visualstudio.com/items?itemName=docsmsft.docs-authoring-pack)
 
@@ -19,9 +19,13 @@ This article describes the steps to interactively install Git client tools and V
 >
 > Major contributors are encouraged to complete these steps, which enable you to use the [major/long-running changes workflow](how-to-write-workflows-major.md). Even if you have write permissions in the main repository, *we highly recommend (and this guide assumes) that you fork and clone the repository*, so that you have read/write permissions to store your proposed changes in your fork.
 
-## Install Git client tools on Windows
+## Install Git client tools 
 
- Install the latest version of [Software Freedom Conservancy's Git client tools](https://git-scm.com/download/). The install includes the Git version control system and Git Bash, the command-line app that you use to interact with your local Git repository.
+ Install the latest version of [Software Freedom Conservancy's Git client tools](https://git-scm.com/download/) for your platform. 
+
+* [Git for Windows](https://git-scm.com/download/win) (This install includes the Git version control system and Git Bash, the command-line app that you use to interact with your local Git repository)
+* [Git for Mac](https://git-scm.com/download/mac)
+* [Git for Linux and Unix](https://git-scm.com/download/linux)
 
 If you prefer a graphical user interface (GUI) over a command-line interface (CLI), see [Software Freedom Conservancy's available GUI Clients page](https://git-scm.com/downloads/guis), [GitHub's GitHub Desktop](https://desktop.github.com/), or [Visual Studio Code](https://www.visualstudio.com/products/code-vs.aspx) for some popular options.
 

--- a/Contribute/get-started-setup-tools.md
+++ b/Contribute/get-started-setup-tools.md
@@ -23,8 +23,8 @@ This article describes the steps to interactively install Git client tools and V
 
  Install the latest version of [Software Freedom Conservancy's Git client tools](https://git-scm.com/download/) for your platform. 
 
-* [Git for Mac](https://git-scm.com/download/mac)
 * [Git for Windows](https://git-scm.com/download/win). This install includes the Git version control system and Git Bash, the command-line app that you use to interact with your local Git repository.
+* [Git for Mac](https://git-scm.com/download/mac). Git for Mac is also provided by Apple as part of the Xcode Command Line Tools. Simply run `git` from the command line and you will be prompted to install the command line tools if needed.  
 * [Git for Linux and Unix](https://git-scm.com/download/linux)
 
 If you prefer a graphical user interface (GUI) over a command-line interface (CLI), see [Software Freedom Conservancy's available GUI Clients page](https://git-scm.com/downloads/guis), [GitHub's GitHub Desktop](https://desktop.github.com/), or [Visual Studio Code](https://www.visualstudio.com/products/code-vs.aspx) for some popular options.

--- a/Contribute/get-started-setup-tools.md
+++ b/Contribute/get-started-setup-tools.md
@@ -23,8 +23,8 @@ This article describes the steps to interactively install Git client tools and V
 
  Install the latest version of [Software Freedom Conservancy's Git client tools](https://git-scm.com/download/) for your platform. 
 
-* [Git for Windows](https://git-scm.com/download/win) (This install includes the Git version control system and Git Bash, the command-line app that you use to interact with your local Git repository)
 * [Git for Mac](https://git-scm.com/download/mac)
+* [Git for Windows](https://git-scm.com/download/win). This install includes the Git version control system and Git Bash, the command-line app that you use to interact with your local Git repository.
 * [Git for Linux and Unix](https://git-scm.com/download/linux)
 
 If you prefer a graphical user interface (GUI) over a command-line interface (CLI), see [Software Freedom Conservancy's available GUI Clients page](https://git-scm.com/downloads/guis), [GitHub's GitHub Desktop](https://desktop.github.com/), or [Visual Studio Code](https://www.visualstudio.com/products/code-vs.aspx) for some popular options.

--- a/Contribute/get-started-setup-tools.md
+++ b/Contribute/get-started-setup-tools.md
@@ -24,7 +24,7 @@ This article describes the steps to interactively install Git client tools and V
  Install the latest version of [Software Freedom Conservancy's Git client tools](https://git-scm.com/download/) for your platform. 
 
 * [Git for Windows](https://git-scm.com/download/win). This install includes the Git version control system and Git Bash, the command-line app that you use to interact with your local Git repository.
-* [Git for Mac](https://git-scm.com/download/mac). Git for Mac is also provided by Apple as part of the Xcode Command Line Tools. Simply run `git` from the command line and you will be prompted to install the command line tools if needed.  
+* Git for Mac is provided as part of the Xcode Command Line Tools. Simply run `git` from the command line. You will be prompted to install the command line tools if needed. You can also download [Git for Mac](https://git-scm.com/download/mac) from the Software Freedom Conservancy.
 * [Git for Linux and Unix](https://git-scm.com/download/linux)
 
 If you prefer a graphical user interface (GUI) over a command-line interface (CLI), see [Software Freedom Conservancy's available GUI Clients page](https://git-scm.com/downloads/guis), [GitHub's GitHub Desktop](https://desktop.github.com/), or [Visual Studio Code](https://www.visualstudio.com/products/code-vs.aspx) for some popular options.


### PR DESCRIPTION
The current instructions are biased for Windows. This updates to include basic macOS and Linux pointers for git, including the fact that git is part of the Xcode Command Line Tools on macOS and will prompt for installation when you try to run git for the first time.