### PR TITLE
C38408: Escaping URL with `

### DIFF
--- a/Contribute/how-to-write-links.md
+++ b/Contribute/how-to-write-links.md
@@ -156,7 +156,7 @@ don't have to specify a version moniker. And you won't have links to conceptual
 content that must be updated when the version changes.
 
 To create the correct link, find the page that you want to link to in your browser, and copy the URL.
-Then, remove ´ "https://docs.microsoft.com" ´ and the locale info.
+Then, remove ` "https://docs.microsoft.com" ` and the locale info.
 
 When you're linking from a TOC, you must use the full URL without the locale information.
 


### PR DESCRIPTION
Hello @DuncanmaMSFT, @BillWagner, @JasonWHowell, @Jemash,
Localization team has reported source content issue that causes localized version to have broken/different format compared to en-us version.  
Proposed fix:   The proposed fix, in this case, is to use the diacritic mark Grave accent  ( ` )  to escape the URL, instead of the acute accent  ( ´ )
Please review and merge the proposed file change to fix to target versions. If you make related fix in another PR  then share your PR number so we can confirm and close this PR.
Many thanks in advance.