### PR TITLE
Update TOC.md

### DIFF
--- a/Contribute/TOC.md
+++ b/Contribute/TOC.md
@@ -16,6 +16,7 @@
 ### [Contribute to .NET docs](dotnet-contribute-process.md)
 ### [.NET docs style conventions](dotnet-style-guide.md)
 ### [Voice and tone guide](dotnet-voice-tone.md)
+# [Additional resources](additional-resources.md)
 
 <!--
 ## Creating new content
@@ -79,4 +80,3 @@
 
      Open question: How to keep this up to date?
    -->
-## [Additional resources](additional-resources.md)


### PR DESCRIPTION
Once, the "Additional resources" link has been at the first TOC level. Fixing that and moving the link up in the file to the uncommented TOC content.