### PR TITLE
Update for PowerApps languages

### DIFF
--- a/Contribute/how-to-write-use-markdown.md
+++ b/Contribute/how-to-write-use-markdown.md
@@ -226,7 +226,8 @@ These languages have friendly name support and most have language highlighting.
 |Objective-C|objc|
 |OData|odata|
 |PHP|php|
-|Power Apps Formula|powerappsfl|
+|PowerApps (dot decimal separator)|powerapps-dot|
+|PowerApps (comma decimal separator)|powerapps-comma|
 |PowerShell|powershell|
 |Python|python|
 |Q#|qsharp|


### PR DESCRIPTION
We are replacing the existing PowerApps entry that was unused with two new langauges: powerapps-dot and powerapps-comma.  There are two languages since we localize the formula language to be user friendly in regions that use "," (comma) as a decimal separator, consistent with what Excel does.  @DuncanmaMSFT has been helping us with setting this up and has reviewed this change.