### PR TITLE
Fixes MicrosoftDocs/Contribute#179

### DIFF
--- a/Contribute/how-to-write-use-markdown.md
+++ b/Contribute/how-to-write-use-markdown.md
@@ -214,6 +214,7 @@ These languages have friendly name support and most have language highlighting.
 |Console|console|
 |CSHTML|cshtml|
 |DAX|dax|
+|Docker|dockerfile|
 |F#|fsharp|
 |Go|go|
 |HTML|html|
@@ -221,6 +222,7 @@ These languages have friendly name support and most have language highlighting.
 |Java|java|
 |JavaScript|javascript|
 |JSON|json|
+|Kusto Query Language|kusto|
 |Markdown|md|
 |Objective-C|objc|
 |OData|odata|


### PR DESCRIPTION
Adding  Docker > dockerfile and Kusto Query Language > kusto to the list of supported languages for code blocks. Reviewed this with Den. 