### PR TITLE
Turn on search scoped for external contribute guide

### DIFF
--- a/Contribute/docfx.json
+++ b/Contribute/docfx.json
@@ -39,7 +39,7 @@
       "extendBreadcrumb": true,
       "titleSuffix": "Contributor Guide",
       "searchScope": ["Contribute"],
-      "hideScope": true,
+      "hideScope": false,
       "feedback_system": "GitHub",
       "feedback_github_repo": "MicrosoftDocs/Contribute",
       "feedback_product_url": "https://aka.ms/sitefeedback",


### PR DESCRIPTION
Turning on searchScope for the external contributor guide (reverse of `hideScope: true` is false) after 48 hours (which was 10 months ago).  See Duncan's commit notes in: https://github.com/MicrosoftDocs/Contribute/commit/359449f4cc7068bfd682401c79c6e4f0bf6f9a05

May help resolve this issue: MicrosoftDocs/Contribute#129