### PR TITLE
New Instructions for Git Bash Users

### DIFF
--- a/Contribute/how-to-write-workflows-major.md
+++ b/Contribute/how-to-write-workflows-major.md
@@ -45,7 +45,29 @@ Isolating related changes to a specific branch allows you to control and introdu
 >[!TIP]
 >Making your changes in the master branch is *not* a good practice. Imagine that you use the master branch to introduce a set of changes for a timed feature release. You finish the changes and are waiting to release them. Then in the interim, you have an urgent request to fix something, so you make the change to a file in the master branch and then publish the change. In this example, you inadvertently publish both the fix *and* the changes that you were holding for release on a specific date.
 
-Now let's create a new working branch in your local repository, to capture your proposed changes. Each git client is different, so consult the help for your preferred client. You can see an overview of the process in the GitHub Guide on [GitHub flow](https://guides.github.com/introduction/flow/).
+Now let's create a new working branch in your local repository, to capture your proposed changes. If you've setup Git Bash (see [Install content authoring tools](get-started-setup-tools.md)), you can create a new branch and "checkout" that branch with one command from within your cloned repository:
+
+````
+git checkout -b "branchname"
+````
+
+Each git client is different, so consult the help for your preferred client. You can see an overview of the process in the GitHub Guide on [GitHub flow](https://guides.github.com/introduction/flow/).
+
+## Making your changes
+
+Now that you have a copy ("clone") of the Microsoft repository and you've created a branch, you're now free to make whatever changes you think would benefit the community using any text or Markdown editor, as outlined on the [Install content authoring tools](get-started-setup-tools.md) page.  You can save your changes locally without needing to submit them to Microsoft until you're ready.
+
+## Saving changes to your repository
+
+Before sending your changes to the author, you must first save them to your Github repository.  Again, while all tools are different, if you're using the Git Bash command line, this can be done in just a few easy steps.
+
+First, from within the repository, you need to _stage_ all of your changes to be commmited.  This can be done by executing:
+
+````
+git add --all
+````
+
+
 
 [!INCLUDE[contribute-how-to-write-workflows-pull-request-processing](includes/contribute-how-to-write-workflows-pull-request-processing.md)]
 

--- a/Contribute/how-to-write-workflows-major.md
+++ b/Contribute/how-to-write-workflows-major.md
@@ -67,7 +67,33 @@ First, from within the repository, you need to _stage_ all of your changes to be
 git add --all
 ````
 
+Next, you need to commit your saved changes to your local repository.  This can be done in Git Bash by running:
 
+````
+git commit -m "Short Description of Changes Made"
+````
+
+Finally, since you created this branch on your local computer, you need to let the fork in your GitHub.com account know about it.  If you're using Git Bash, this can be done by running:
+
+````
+git push --set-upstream origin <branchname>
+````
+
+You've done it!  Your code is now up in your GitHub repository and ready for you to create a pull request.  
+
+>[!TIP]
+> Even though your changes become visible in your personal GitHub account when you push them, there is no rule that you need to submit a pull request immediately.  If you want to come stop and return at a later time to make additional tweaks, that's OK!
+
+Need to fix something you submitted?  No problem!  Just make your changes in the same branch and then commit and push again (no need to set the upstream server on subsequent pushes of the same branch).
+
+Got more changes you need to make unrelated to this one?  Switch back to the master branch and checkout another fresh branch,  Using Git Bash, this is as easy as:
+
+````
+git checkout master
+git checkout -b "branchname"
+````
+
+You're now back in a new branch and you're well on your way to being a master contributer.
 
 [!INCLUDE[contribute-how-to-write-workflows-pull-request-processing](includes/contribute-how-to-write-workflows-pull-request-processing.md)]
 


### PR DESCRIPTION
The contribute instructions seem to suggest users use Git Bash, and then even has a few examples, but then on the final page assumes they could be using any Git product and they should consult the manual.  Since we assume Git Bash up until now, I expanded upon the workflow to show how to checkout a branch, commit to that branch, and push it upstream.