### PR TITLE
Removed extra #sign-off line from review table

### DIFF
--- a/Contribute/includes/contribute-how-to-pull-requests-apex-automation.md
+++ b/Contribute/includes/contribute-how-to-pull-requests-apex-automation.md
@@ -4,6 +4,5 @@ Comment automation enables read-level users (users who don't have write permissi
 | Hashtag comment | What it does | Repo availability |
 | --- | --- | --- |
 | #sign-off |When the author of an article types the **#sign-off** comment in the comment stream, the **ready-to-merge** label is assigned. This label lets the reviewers in the repo know when a pull request is ready for review/merge. |Public and private |
-| #sign-off |If a contributor who is *not* the listed author tries to sign off on a public pull request by using the **#sign-off** comment, a message is written to the pull request indicating that only the author can assign the label. |Public |
 | #hold-off |Authors can type **#hold-off** in a PR comment to remove the **ready-to-merge** label--in case they change their mind or make a mistake. In the private repo, this assigns the **do-not-merge** label. |Public and private |
 | #please-close |Authors can type **#please-close** in the comment stream to close the pull request if they decide not to have the changes merged. |Public |


### PR DESCRIPTION
Since all commands are author only, having one of the three options called out separately doesn't really serve a purpose.