### PR TITLE
updates to markdown extension section

### DIFF
--- a/Contribute/how-to-write-use-markdown.md
+++ b/Contribute/how-to-write-use-markdown.md
@@ -548,7 +548,6 @@ Syntax:
     * `id`: `snippet_Create` The ID of the snippet that needs to be inserted from the code file. This value cannot co-exist with range.
     * `highlight`: `2-4,6` Range and/or numbers of lines that need to be highlighted in the generated code snippet. The numbering is relative to the code snippet itself, not the imported range.
     * `interactive`: `cloudshell-powershell`, `cloudshell-bash`, `try-dotnet`, `try-dotnet-class`, `try-dotnet-method` String value determines what kinds of interactivity are enabled.
-    * For details about tag name representation in code snippet source files by language, see the [DocFX guidelines](https://dotnet.github.io/docfx/spec/docfx_flavored_markdown.html#tag-name-representation-in-code-snippet-source-file).
 
 #### Supported languages
 

--- a/Contribute/how-to-write-use-markdown.md
+++ b/Contribute/how-to-write-use-markdown.md
@@ -383,10 +383,227 @@ You can see an example of selectors in action at the [Azure docs](https://docs.m
 
 ### Code include references
 
-Markdig supports advanced inclusion of code in an article, via its code snippet extension. It provides advanced rendering that builds on GFM features such as programming language selection and syntax coloring, plus nice features such as:
+The Docs code snippet Markdown extension allows you to embed code samples in your articles and render them with language-specific syntax coloring. You can include code from either the current repository or another repository. The instructions below provides an overview of how to use the feature with the [docs.microsoft.com Authoring Pack](https://marketplace.visualstudio.com/items?itemName=docsmsft.docs-authoring-pack).
 
-- Inclusion of centralized code samples/snippets from an external repository.
-- Tabbed UI to show multiple versions of code samples in different languages.
+> [!NOTE]
+> The extension does not support including code content within it inline – this is to be done through the standard triple-tick Markdown convention.
+
+#### Code from current repository
+
+1. In Visual Studio Code, click **Alt + M** or **Option + M** and select Snippet.
+2. Once Snippet is selected, you will be prompted for Full Search, Scoped Search or Cross-Repository Reference. To search locally, select Full Local Search.
+3. Enter a search term to find the file. Once you’ve found the file, select the file.
+4. Next, select an option to determine which line(s) of code should be included in the snippet. The options are: **ID**, **Range** and **None**.
+5. Based on your selection from Step 4, provide a value if necessary.
+
+Display entire code file:
+
+```markdown
+:::code language="csharp" source="intro/samples/cu/Controllers/StudentsController.cs":::
+```
+
+Display part of a code file by specifying line numbers:
+
+```markdown
+:::code language="csharp" source="intro/samples/cu/Controllers/StudentsController.cs" range="2-24,26":::
+```
+
+Display part of a code file by a snippet name:
+
+```markdown
+:::code language="csharp" source="intro/samples/cu/Controllers/StudentsController.cs" id="snippet_Create":::
+```
+
+#### Code from another repository
+
+1. In Visual Studio Code, click **Alt + M** or **Option + M** and select Snippet.
+2. Once Snippet is selected, you will be prompted for Full Search, Scoped Search or Cross-Repository Reference. To search across repositories, select Cross-Repository Reference.
+3. You will be given a selection of repositories that are in *.openpublishing.publish.config.json*. Select a repository.
+3. Enter a search term to find the file. Once you’ve found the file, select the file.
+4. Next, select an option to determine which line(s) of code should be included in the snippet. The options are: **ID**, **Range** and **None**.
+5. Based on your selection from Step 5, provide a value if necessary.
+
+Your snippet reference will look like this:
+
+```markdown
+:::code language="csharp" source="~/samples-durable-functions/samples/csx/shared/Location.csx" highlight="2,5":::
+```
+
+#### Path to code file
+
+Example:
+
+```markdown
+:::code language="csharp" source="intro/samples/cu/Controllers/StudentsController.cs" range="2-24,26":::
+```
+
+The example is from the ASP.NET docs repo, [aspnetcore/data/ef-mvc/crud.md](https://github.com/aspnet/Docs/blob/master/aspnetcore/data/ef-mvc/crud.md)
+article file. The code file is referenced by a relative path to
+[aspnetcore/data/ef-mvc/intro/samples/cu/Controllers/StudentsController.cs](https://github.com/aspnet/Docs/blob/master/aspnetcore/data/ef-mvc/intro/samples/cu/Controllers/StudentsController.cs)
+in the same repository.
+
+#### Selected line numbers
+
+Example:
+
+```markdown
+:::code language="csharp" source="intro/samples/cu/Controllers/StudentsController.cs" range="2-24,26":::
+```
+
+This example displays only lines 2-24 and 26 of the *StudentController.cs* code file.
+
+Prefer snippets over hard-coded line numbers, as explained in the next section.
+
+#### Named snippet
+
+Example:
+
+```markdown
+:::code language="csharp" source="intro/samples/cu/Controllers/StudentsController.cs" id="snippet_Create":::
+```
+
+Use only letters and underscores for the name.
+
+The example displays the `snippet_Create` section of the code file. The code file for this example
+has a C# region named `snippet_Create`:
+
+```cs
+// code excluded from the snippet
+// <snippet_Create>
+// code included in the snippet
+// </snippet_Create>
+// code excluded from the snippet
+```
+
+Whenever you can, refer to a named section rather than specifying line numbers. Line number
+references are brittle because code files inevitably change in ways that make line numbers change.
+You don't necessarily get notified of such changes. Your article eventually starts showing the wrong
+lines and you have no clue anything has changed.
+
+#### Highlighting selected lines
+
+Example:
+
+```markdown
+:::code language="csharp" source="intro/samples/cu/Controllers/StudentsController.cs" range="2-24,26" highlight="2,5":::
+```
+
+The example highlights lines 2 and 5, counting from the start of the displayed snippet. (Line
+numbers to highlight don't count from the start of the code file.) In other words, lines 3 and 6
+of the code file are highlighted.
+
+#### Interactive code snippets
+
+You can enable interactive mode for code snippets included by reference. Here are examples:
+
+```markdown
+:::code source="PowerShell.ps1" interactive="cloudshell-powershell":::
+```
+
+```markdown
+:::code source="Bash.sh" interactive="cloudshell-bash":::
+```
+
+To turn on this feature for a particular code block, use the `interactive` attribute. The
+available attribute values are:
+
+* `cloudshell-powershell` - Enables the Azure PowerShell Cloud Shell, as in the preceding
+  example
+* `cloudshell-bash` - Enables the Azure Cloud Shell
+* `try-dotnet` - Enables Try .NET
+* `try-dotnet-class` - Enables Try .NET with class scaffolding
+* `try-dotnet-method` - Enables Try .NET with method scaffolding
+
+For the Azure Cloud Shell and PowerShell Cloud Shell, users can run commands against only their own
+Azure account.
+
+
+#### Snippet syntax reference
+
+You can reference code snippets stored in your repo by using the specified code language. The
+content of the specified code path will be expanded and included in your file.
+
+There aren't restrictions on the folder structure of code snippets. You can manage the code snippets
+as normal source code.
+
+Syntax:
+
+```md
+:::code language="<language>" source="<path>" <attribute>="<attribute-value>":::
+```
+
+> [!IMPORTANT]
+> This syntax is a block Markdown extension. It must be used on its own line.
+
+* `<language>` (*optional*)
+  * Language of the code snippet. For more information, see the [Supported languages](#supported-languages)
+    section later in this article.
+
+* `<path>` (*mandatory*)
+  * Relative path in the file system that indicates the code snippet file to reference.
+
+* `<attribute>` and `<attribute-value>` (*optional*)
+  * Used together to specify how the code should be retrieved from the file:
+    * `range`: `1,3-5` A range of lines. This example includes lines 1, 3, 4, and 5.
+    * `id`: `snippet_Create` The ID of the snippet that needs to be inserted from the code file. This value cannot co-exist with range.
+    * `highlight`: `2-4,6` Range and/or numbers of lines that need to be highlighted in the generated code snippet. The numbering is relative to the code snippet itself, not the imported range.
+    * `interactive`: `cloudshell-powershell`, `cloudshell-bash`, `try-dotnet`, `try-dotnet-class`, `try-dotnet-method` String value determines what kinds of interactivity are enabled.
+    * For details about tag name representation in code snippet source files by language, see the [DocFX guidelines](https://dotnet.github.io/docfx/spec/docfx_flavored_markdown.html#tag-name-representation-in-code-snippet-source-file).
+
+#### Supported languages
+
+|Name|Markdown label|
+|-----|-------|
+|.NET Core CLI|`dotnetcli`|
+|ASP.NET with C#|`aspx-csharp`|
+|ASP.NET with VB|`aspx-vb`|
+|Azure CLI|`azurecli`|
+|Azure CLI in browser|`azurecli-interactive`|
+|Azure PowerShell in browser|`azurepowershell-interactive`|
+|AzCopy|`azcopy`|
+|Bash|`bash`|
+|C++|`cpp`|
+|C#|`csharp`|
+|C# in browser|`csharp-interactive`|
+|Console|`console`|
+|CSHTML|`cshtml`|
+|DAX|`dax`|
+|Docker|`Dockerfile`|
+|F#|`fsharp`|
+|HTML|`html`|
+|Java|`java`|
+|JavaScript|`javascript`|
+|JSON|`json`|
+|Kusto Query Language|`kusto`|
+|Markdown|`md`|
+|Objective-C|`objc`|
+|PHP|`php`|
+|PowerShell|`powershell`|
+|Power Query M|`powerquery-m`|
+|protobuf|`protobuf`|
+|Python|`python`|
+|Ruby|`ruby`|
+|SQL|`sql`|
+|Swift|`swift`|
+|VB|`vb`|
+|XAML|`xaml`|
+|XML|`xml`|
+|YAML|`yml`|
+
+#### Code extensions
+
+|Name|Markdown label|File extension|
+|-----|-------|-----|
+|C#|csharp|.cs, .csx|
+|C++|cpp|.cpp, .h|
+|F#|fsharp|.fs|
+|Java|java|.java|
+|JavaScript|javascript|.js|
+|Python|python|.py|
+|SQL|sql|.sql|
+|VB|vb|.vb|
+|XAML|xaml|.xaml|
+|XML|xml|.xml|
 
 ## Gotchas and troubleshooting
 


### PR DESCRIPTION
Recently updated the Docs Contributor Guide for internal use in this PR: https://review.docs.microsoft.com/en-us/help/contribute/code-in-docs?branch=pr-en-us-2752

This external doc needed to be updated to reflect the new feature as well.