### PR TITLE
fix snippet identifiers and code error

### DIFF
--- a/Contribute/how-to-write-use-markdown.md
+++ b/Contribute/how-to-write-use-markdown.md
@@ -207,7 +207,6 @@ These languages have friendly name support and most have language highlighting.
 |C++/CX|cppcx|
 |C++/WinRT|cppwinrt|
 |C#|csharp|
-|C# in browser|csharp-interactive|
 |Console|console|
 |CSHTML|cshtml|
 |DAX|dax|
@@ -238,8 +237,6 @@ These languages have friendly name support and most have language highlighting.
 |VB|vb|
 |XAML|xaml|
 |XML|xml|
-
-The `csharp-interactive` name specifies the C# language, and the ability to run the samples from the browser. These snippets are compiled and executed in a Docker container, and the results of that program execution are displayed in the user's browser window.
 
 #### Example: C\#
 
@@ -658,13 +655,10 @@ Syntax:
 |ASP.NET with C#|`aspx-csharp`|
 |ASP.NET with VB|`aspx-vb`|
 |Azure CLI|`azurecli`|
-|Azure CLI in browser|`azurecli-interactive`|
-|Azure PowerShell in browser|`azurepowershell-interactive`|
 |AzCopy|`azcopy`|
 |Bash|`bash`|
 |C++|`cpp`|
 |C#|`csharp`|
-|C# in browser|`csharp-interactive`|
 |Console|`console`|
 |CSHTML|`cshtml`|
 |DAX|`dax`|

--- a/Contribute/how-to-write-use-markdown.md
+++ b/Contribute/how-to-write-use-markdown.md
@@ -546,32 +546,32 @@ Example:
 
 Code Snippet without Class Scaffolding Applied
 
-```md
+```csharp
 public static void Main()
+{
+    // Specify the data source.  
+    int[] scores = new int[] { 97, 92, 81, 60 };        // Define the query expression.
+
+    IEnumerable<int> scoreQuery =
+        from score in scores  
+        where score > 80  
+        select score;
+
+    // Execute the query.  
+    foreach (int i in scoreQuery)
     {  
-        // Specify the data source.  
-        int[] scores = new int[] { 97, 92, 81, 60 };        // Define the query expression.
-
-        IEnumerable<int> scoreQuery =
-            from score in scores  
-            where score > 80  
-            select score;
-
-        // Execute the query.  
-        foreach (int i in scoreQuery)
-        {  
-            Console.Write(i + " ");
-        }
-    }  
+        Console.Write(i + " ");
+    }
 }
 ```
 
 Code Snippet with Class Scaffolding Applied
 
-```md
-class NameOfClass {
+```csharp
+class NameOfClass
+{
 
-   public static void Main()
+    public static void Main()
     {
         // Specify the data source.
         int[] scores = new int[] { 97, 92, 81, 60 };
@@ -587,7 +587,7 @@ class NameOfClass {
         {
             Console.Write(i + " ");
         }
-    }  
+    }
 }
 ```
 
@@ -601,20 +601,21 @@ Example:
 
 Code Snippet without Method Scaffolding Applied
 
-```md
+```csharp
 /*Print some string in C#*/
 
-Console.WriteLine("Hello C#.);
+Console.WriteLine("Hello C#");
 ```
 
 Code Snippet with Method Scaffolding Applied
 
 ```md
-public static void Main(string args[]) {
+public static void Main(string args[])
+{
 
 /*Print some string in C#*/
 
-Console.WriteLine("Hello C#.);
+Console.WriteLine("Hello C#");
 }
 ```
 


### PR DESCRIPTION
I've removed x-interactive languages, I think they're no longer valid as a "whole" language identifier.

For example, the language="csharp-interactive" should be language="csharp" and interactive="try-dotnet"