### PR TITLE
Remove now redundant ext icon

### DIFF
--- a/Contribute/docs-authoring/includes/image-extension.md
+++ b/Contribute/docs-authoring/includes/image-extension.md
@@ -2,10 +2,10 @@
 author: IEvangelist
 ms.prod: non-product-specific
 ms.topic: contributor-guide
-ms.date: 03/03/2020
+ms.date: 03/11/2021
 ms.author: dapine
 ---
 
 ## Extension name
 
-The Docs Authoring Pack, Visual Studio Code meta extension is comprised of multiple sub extensions. This feature is included in the <a href="https://marketplace.visualstudio.com/items?itemName=docsmsft.docs-images" target="_blank">Docs Images <span class="docon docon-navigate-external x-hidden-focus"></span></a> extension. The Docs Markdown extension is part of the Docs Authoring Pack, there is no need to install it separately.
+The Docs Authoring Pack, Visual Studio Code meta extension is comprised of multiple sub extensions. This feature is included in the <a href="https://marketplace.visualstudio.com/items?itemName=docsmsft.docs-images" target="_blank">Docs Images</a> extension. The Docs Markdown extension is part of the Docs Authoring Pack, there is no need to install it separately.

--- a/Contribute/docs-authoring/includes/markdown-extension.md
+++ b/Contribute/docs-authoring/includes/markdown-extension.md
@@ -2,10 +2,10 @@
 author: IEvangelist
 ms.prod: non-product-specific
 ms.topic: contributor-guide
-ms.date: 03/03/2020
+ms.date: 03/11/2021
 ms.author: dapine
 ---
 
 ## Extension name
 
-The Docs Authoring Pack, Visual Studio Code meta extension is comprised of multiple sub extensions. This feature is included in the <a href="https://marketplace.visualstudio.com/items?itemName=docsmsft.docs-markdown" target="_blank">Docs Markdown <span class="docon docon-navigate-external x-hidden-focus"></span></a> extension. The Docs Markdown extension is part of the Docs Authoring Pack, there is no need to install it separately.
+The Docs Authoring Pack, Visual Studio Code meta extension is comprised of multiple sub extensions. This feature is included in the <a href="https://marketplace.visualstudio.com/items?itemName=docsmsft.docs-markdown" target="_blank">Docs Markdown</a> extension. The Docs Markdown extension is part of the Docs Authoring Pack, there is no need to install it separately.


### PR DESCRIPTION
Remove the now redundant EXT icon

![image](https://user-images.githubusercontent.com/7679720/110797584-d8b11800-823e-11eb-9793-6b7504de6750.png)

/cc @Jim-Parker 