### PR TITLE
Remove the Edit button from this page

### DIFF
--- a/Contribute/docfx.json
+++ b/Contribute/docfx.json
@@ -40,7 +40,7 @@
       "titleSuffix": "Contributor Guide",
       "searchScope": ["Contribute"],
       "hideScope": false,
-      "feedback_system": "GitHub",
+      "feedback_system": "None",
       "feedback_github_repo": "MicrosoftDocs/Contribute",
       "feedback_product_url": "https://aka.ms/sitefeedback",
       "author": "billwagner",


### PR DESCRIPTION
There has been some confusion https://github.com/MicrosoftDocs/Contribute.de-DE/pull/5#issuecomment-800431868 over whether contributions will be accepted on localized repos. After consulting with the Loc team, it sounds like the decision has been made not to support contributions for localized content with the exception of Azure docs in specific locations.
However, the contribution link still appears in the footer across all docs pages - including localized pages. Even though the "Edit" button has been removed, if someone selects the "Contribute" link in the footer, they are taken to this page. The most simple fix at the current time, seems to be to remove the "Edit" button from this page as well. This seems to be primarily internally-driven content, so not sure why external customers would want to contribute anyhow... with the exception of translating, as seen in the PR linked above.