### PR TITLE
Add Action to check for build warnings

### DIFF
--- a/.github/workflows/check-build-warnings.yml
+++ b/.github/workflows/check-build-warnings.yml
@@ -1,0 +1,14 @@
+name: 'Status checker'
+
+on: 
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  status_checker_job:
+    name: Look for build warnings
+    runs-on: ubuntu-latest
+    steps:
+    - uses: dotnet/samples/.github/actions/status-checker@main
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This GitHub Action turns the status checks section red (failure) if there are any build warnings. This helps to prevents PRs that introduce new build warnings from being merged. (But you can still merge the PR if you want. It doesn't block.)

This is what the status checks section will look like if there are build warnings:

![image](https://user-images.githubusercontent.com/24882762/115932873-abad7300-a442-11eb-90d4-add9782021f3.png)
