### PR TITLE
Update code-in-docs.md

### DIFF
--- a/Contribute/code-in-docs.md
+++ b/Contribute/code-in-docs.md
@@ -702,6 +702,8 @@ The [Docs Authoring Pack](how-to-write-docs-auth-pack.md) includes a feature to 
 | Vala                           | `vala`                                                                         |
 | Verilog                        | `verilog`, `v`                                                                 |
 | Vim Script                     | `vim`                                                                          |
+| Visual Basic                   | `vb`                                                                           |
+| Visual Basic for Applications  | `vba`                                                                          |
 | X++                            | `xpp`                                                                          |
 | x86 Assembly                   | `x86asm`                                                                       |
 | XL                             | `xl`, `tao`                                                                    |


### PR DESCRIPTION
Visual Basic (`vb`) and Visual Basic for Applications (`vba`) both are listed in Dev Lang taxonomies for Docs in the internal contributor guide: https://review.docs.microsoft.com/en-us/help/contribute/metadata-taxonomies?branch=master#dev-lang. OK to add to the external guide?