### PR TITLE
align public CG with internal CG in re consecutive alerts

### DIFF
--- a/Contribute/markdown-reference.md
+++ b/Contribute/markdown-reference.md
@@ -55,6 +55,8 @@ These alerts look like this on Docs:
 > [!WARNING]
 > Dangerous certain consequences of an action.
 
+Multiple notes should never be next to each other in an article.
+
 ## Angle brackets
 
 If you use angle brackets in text in your file (for example, to denote a placeholder), you need to manually encode the angle brackets. Otherwise, Markdown thinks that they're intended to be an HTML tag.

--- a/Contribute/markdown-reference.md
+++ b/Contribute/markdown-reference.md
@@ -19,7 +19,13 @@ You can use any text editor to write Markdown, but we recommend [Visual Studio C
 
 ## Alerts (Note, Tip, Important, Caution, Warning)
 
-Alerts are a Markdown extension to create block quotes that render on Docs with colors and icons that indicate the significance of the content. The following alert types are supported:
+Alerts are a Markdown extension to create block quotes that render on Docs with colors and icons that indicate the significance of the content. 
+
+Avoid notes, tips, and important boxes. Readers tend to skip over them. It's better to put that info directly into the article text.
+
+If you need to use alerts, limit them to one or two per article. Multiple notes should never be next to each other in an article.
+
+The following alert types are supported:
 
 ```markdown
 > [!NOTE]
@@ -54,8 +60,6 @@ These alerts look like this on Docs:
 
 > [!WARNING]
 > Dangerous certain consequences of an action.
-
-Multiple notes should never be next to each other in an article.
 
 ## Angle brackets
 


### PR DESCRIPTION
Add/echo sentence that's in the internal contributor guide in the external contributor guide. In the public repos, we frequently see external contributors creating consecutive alerts in their pull requests. It would be good to have public style guidance to point to to steer them away from doing it (rather than saying "internal style guidance is to avoid . . ."). Thanks.