### PR TITLE
Remove ability to add a blank issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Microsoft Security Policy
+    url: https://github.com/MicrosoftDocs/Contribute/security/policy
+    about: Read about and report security vulnerabilities here.


### PR DESCRIPTION
Per these instructions: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser