### PR TITLE
Create PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+# Contributor guide pull request
+
+Thanks for contributing to the [docs.microsoft.com contributor guide](https://docs.microsoft.com/contribute/?branch=main). Please read these instructions for processing your pull request (PR). Once you've read this text, delete it and write a brief description of the changes you're proposing.
+
+## Quality control
+
+- [ ] 1. **Successful build with no warnings**: Review the build status to make sure **all checks are green** (Succeeded).
+
+- [ ] 2. **#Sign-off**: Once the PR is finalized and ready to be merged, indicate so by typing `#sign-off` in a new comment in the PR. Signing off means the document is ready for review and can be published at any time.
+
+## Merge and publish
+
+- All PRs to this repository are manually reviewed and merged.
+- Once all feedback on the PR is addressed, we'll merge the PR into the main branch.
+
+## Need help?
+
+- See our guidance on [Contributing to the contributor guide](/contribute/?branch=main) for help with adding or updating content in this contributor guide.
+- Write to the PR reviewer in the PR comments: `@carlyrevier, @jehchow`


### PR DESCRIPTION
Thought we might want to create one of these like we have for the internal guide. Followed these instructions: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository