### PR TITLE
Remove Hacktoberfest from TOC

### DIFF
--- a/Contribute/TOC.yml
+++ b/Contribute/TOC.yml
@@ -74,7 +74,5 @@
           href: dotnet/net-core-5-naming.md
     - name: PowerShell-Docs
       href: powershell-overview.md
-- name: Hacktoberfest
-  href: hacktoberfest.md
 - name: Additional resources
   href: additional-resources.md


### PR DESCRIPTION
Removing article from the TOC but not archiving all together in case we want to use it next year.