### PR TITLE
Use kbd HTML tags

### DIFF
--- a/Contribute/text-formatting-guidelines.md
+++ b/Contribute/text-formatting-guidelines.md
@@ -170,12 +170,12 @@ and mixing other styles in them looks bad.
 When referring to keys or key combinations, follow these conventions:
 
 * Capitalize the first letter of key names.
-* Don't apply an inline style such as italics, bold, or code.
-* Use "+" to join keys that are pressed at the same time.
+* Surround the key names with `<kbd>` and `</kbd>` HTML tags.
+* Use "+" to join keys that the user selects at the same time.
 
-### Examples
+### Examples of keys and keyboard shortcuts
 
-* **This**: Select Alt+Ctrl+S.
+* **This**: Select \<kbd>Alt\</kbd>+\<kbd>Ctrl\</kbd>+\<kbd>S\</kbd>, rendered as <kbd>Alt</kbd>+<kbd>Ctrl</kbd>+<kbd>S</kbd>.
 * **Not this**: Press **ALT+CTRL+S**.
 * **Not this**: Hit `ALT+CTRL+S`.
 

--- a/Contribute/text-formatting-guidelines.md
+++ b/Contribute/text-formatting-guidelines.md
@@ -175,7 +175,7 @@ When referring to keys or key combinations, follow these conventions:
 
 ### Examples of keys and keyboard shortcuts
 
-* **This**: Select \<kbd>Alt\</kbd>+\<kbd>Ctrl\</kbd>+\<kbd>S\</kbd>, rendered as <kbd>Alt</kbd>+<kbd>Ctrl</kbd>+<kbd>S</kbd>.
+* **This**: Select <kbd>Alt</kbd>+<kbd>Ctrl</kbd>+<kbd>S</kbd>.
 * **Not this**: Press **ALT+CTRL+S**.
 * **Not this**: Hit `ALT+CTRL+S`.
 


### PR DESCRIPTION
Using `<kbd>` tags to identify keys is an accessibility issue; it enables screen readers to recognize references to keyboard keys.