### PR TITLE
Removed reference to the Atom editor because the creators of it are s…

### DIFF
--- a/Contribute/get-started-setup-tools.md
+++ b/Contribute/get-started-setup-tools.md
@@ -71,7 +71,7 @@ For more information, see [Learn Authoring Pack for Visual Studio Code](how-to-w
 
 ## Understand Markdown editors
 
-Markdown is a lightweight markup language used to author the content. [Visual Studio Code](https://code.visualstudio.com/) is the preferred tool for editing Markdown at Microsoft. Other markdown editing tools are available. Markdown basics and the features supported by Open Publishing Services (OPS) custom Markdown extensions, are covered in the [Markdown Reference](markdown-reference.md) article.
+Markdown is a lightweight markup language used to author the content. [Visual Studio Code](https://code.visualstudio.com/) is the preferred tool for editing Markdown at Microsoft. Other Markdown editing tools are available. The [Markdown Reference](markdown-reference.md) article covers Markdown basics and the features supported by Open Publishing Services (OPS) custom Markdown extensions. 
 
 ## Next steps
 

--- a/Contribute/get-started-setup-tools.md
+++ b/Contribute/get-started-setup-tools.md
@@ -71,7 +71,7 @@ For more information, see [Learn Authoring Pack for Visual Studio Code](how-to-w
 
 ## Understand Markdown editors
 
-Markdown is a lightweight markup language used to author the content. [Visual Studio Code](https://code.visualstudio.com/) is the preferred tool for editing Markdown at Microsoft. [Atom](https://atom.io) is another popular tool for editing Markdown. Markdown basics and the features supported by Open Publishing Services (OPS) custom Markdown extensions, are covered in the [Markdown Reference](markdown-reference.md) article.
+Markdown is a lightweight markup language used to author the content. [Visual Studio Code](https://code.visualstudio.com/) is the preferred tool for editing Markdown at Microsoft. Other markdown editing tools are available. Markdown basics and the features supported by Open Publishing Services (OPS) custom Markdown extensions, are covered in the [Markdown Reference](markdown-reference.md) article.
 
 ## Next steps
 


### PR DESCRIPTION
…unsetting the application. This is currently stated at https://github.blog/2022-06-08-sunsetting-atom/

# Contributor guide pull request

Atom is referenced as a popular tool for editing Markdown. It may still be popular, but it is being retired, so I suggest removing it. See https://github.blog/2022-06-08-sunsetting-atom/ for more information

## Quality control

- [x] 1. **Successful build with no warnings**: Review the build status to make sure **all checks are green** (Succeeded).

- [x] 2. **#Sign-off**: Once the PR is finalized and ready to be merged, indicate so by typing `#sign-off` in a new comment in the PR. Signing off means the document is ready for review and can be published at any time.

## Merge and publish

- All PRs to this repository are manually reviewed and merged.
- Once all feedback on the PR is addressed, we'll merge the PR into the main branch.

## Need help?

- See our guidance on [Contributing to the contributor guide](/contribute/?branch=main) for help with adding or updating content in this contributor guide.
- Write to the PR reviewer in the PR comments: `@carlyrevier, @jehchow`
