### PR TITLE
Removed an extra word that caused confusion: come.

### DIFF
--- a/Contribute/how-to-write-workflows-major.md
+++ b/Contribute/how-to-write-workflows-major.md
@@ -85,7 +85,7 @@ git push --set-upstream origin <branchname>
 You've done it!  Your code is now up in your GitHub repository and ready for you to create a pull request.  
 
 >[!TIP]
-> Even though your changes become visible in your personal GitHub account when you push them, there is no rule that you need to submit a pull request immediately.  If you want to come stop and return at a later time to make additional tweaks, that's OK!
+> Even though your changes become visible in your personal GitHub account when you push them, there is no rule that you need to submit a pull request immediately.  If you want to stop and return at a later time to make additional tweaks, that's OK!
 
 Need to fix something you submitted?  No problem!  Just make your changes in the same branch and then commit and push again (no need to set the upstream server on subsequent pushes of the same branch).
 


### PR DESCRIPTION
# Contributor guide pull request

It appears that the word "come" was left behind after a previous rewrite of a sentence: "If you want to ~~come~~ stop and return at a later time to make additional tweaks, that's OK!"

## Quality control

- [x] 1. **Successful build with no warnings**: Review the build status to make sure **all checks are green** (Succeeded).

- [x] 2. **#Sign-off**: Once the PR is finalized and ready to be merged, indicate so by typing `#sign-off` in a new comment in the PR. Signing off means the document is ready for review and can be published at any time.

## Merge and publish

- All PRs to this repository are manually reviewed and merged.
- Once all feedback on the PR is addressed, we'll merge the PR into the main branch.

## Need help?

- See our guidance on [Contributing to the contributor guide](/contribute/?branch=main) for help with adding or updating content in this contributor guide.
- Write to the PR reviewer in the PR comments: `@carlyrevier, @jehchow`
