### PR TITLE
Update check-build-warnings.yml

### DIFF
--- a/.github/workflows/check-build-warnings.yml
+++ b/.github/workflows/check-build-warnings.yml
@@ -13,7 +13,8 @@ jobs:
         issues: write
         pull-requests: write
     steps:
-    - uses: dotnet/docs-actions/actions/status-checker@main
+    - uses: actions/checkout@v3
+    - uses: dotnet/docs-tools/actions/status-checker@main
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
         docs_path: "Contribute"


### PR DESCRIPTION
Attention @carlyrevier: I believe the issue is that the status checker was updated, however; the consuming workflow wasn't. It now requires an explicit `@actions/checkout` prior to consumption such that the source is available to evaluate in the context of the workflow run.

See https://github.com/dotnet/docs/blob/main/.github/workflows/check-for-build-warnings.yml