### PR TITLE
Tiny markdown fix for "articles" in git-github-fundamentals.md

### DIFF
--- a/Contribute/content/git-github-fundamentals.md
+++ b/Contribute/content/git-github-fundamentals.md
@@ -64,7 +64,7 @@ A project's default branch serves as the current version of content for the proj
 
 #### Articles subdirectory
 
-You can typically find a main `articles` directory off the root of the repository. The `articles`` directory contains a set of subdirectories Articles in the subdirectories are formatted as Markdown files that use an *.md* extension. Some repositories that support multiple services use a
+You can typically find a main `articles` directory off the root of the repository. The `articles` directory contains a set of subdirectories Articles in the subdirectories are formatted as Markdown files that use an *.md* extension. Some repositories that support multiple services use a
 generic `/articles` subdirectory, such as the [Azure-Docs](https://github.com/MicrosoftDocs/Azure-Docs) repository. Others might use a
 service-specific name, such as the [IntuneDocs](https://github.com/MicrosoftDocs/IntuneDocs) repository, which uses `/IntuneDocs`.
 


### PR DESCRIPTION
Tiny markdown fix: in one place the word articles had was surrounded by an inconsistent number of back-ticks (1 before and 2 afterwards). 

Fixed by surrounding it by 1 back-tick to match what was done earlier in the same sentence. Verified by looking at the 'preview' Windows

# Contributor guide pull request

Thanks for contributing to the [Microsoft Learn contributor guide](https://learn.microsoft.com/contribute/?branch=main). Please read these instructions for processing your pull request (PR). Once you've read this text, delete it and write a brief description of the changes you're proposing.

## Quality control

- [ ] 1. **Successful build with no warnings**: Review the build status to make sure **all checks are green** (Succeeded).

- [ ] 2. **#Sign-off**: Once the PR is finalized and ready to be merged, indicate so by typing `#sign-off` in a new comment in the PR. Signing off means the document is ready for review and can be published at any time.

## Merge and publish

- All PRs to this repository are manually reviewed and merged.
- Once all feedback on the PR is addressed, we'll merge the PR into the main branch.

## Need help?

- If you have an open PR, tag the PR reviewers in comment with your question: `@carlyrevier, @jehchow`
- Open an issue in this repo and tag the PR reviewers.
