### PR TITLE
TEST contribution

### DIFF
--- a/Contribute/content/index.md
+++ b/Contribute/content/index.md
@@ -11,6 +11,8 @@ ms.custom: external-contributor-guide
 
 # Contribute to the Microsoft Learn platform
 
+Microsoft Learn hosts all documentation for Microsoft products and technologies.
+
 Welcome to the Microsoft Learn contributor guide! This documentation introduces you to the ways you can contribute to the Microsoft Learn platform and teaches you how to get started.
 
 Sharing your expertise with others on Microsoft Learn helps everyone achieve more. Use the information in this guide to publish a new article to Microsoft Learn, update a published article, answer questions on Microsoft Q&A, and more.


### PR DESCRIPTION
Added a more descriptive heading `Microsoft Learn hosts all documentation for Microsoft products and technologies.` underneath the "Contribute to the Microsoft Learn platform.
