### PR TITLE
Fix outdated label references and links

### DIFF
--- a/Contribute/content/dotnet/dotnet-contribute.md
+++ b/Contribute/content/dotnet/dotnet-contribute.md
@@ -43,7 +43,7 @@ Following these guidelines will ensure a better experience for you and for us.
 
 Choose an existing issue and address it. You can look at our [open issues](https://github.com/dotnet/docs/issues) list and volunteer to work on the ones you're interested in:
 
-- Filter by the [good first issue](https://github.com/dotnet/docs/labels/good first issue) label for, well, good first issues.
+- Filter by the [good first issue](https://github.com/dotnet/docs/labels/good%20first%20issue) label for, well, good first issues.
 - Filter by the [help wanted](https://github.com/dotnet/docs/labels/help wanted) label for issues appropriate for community contribution. These issues usually require minimal context.
 - Experienced contributors can tackle any issues of interest.
 

--- a/Contribute/content/dotnet/dotnet-contribute.md
+++ b/Contribute/content/dotnet/dotnet-contribute.md
@@ -43,8 +43,8 @@ Following these guidelines will ensure a better experience for you and for us.
 
 Choose an existing issue and address it. You can look at our [open issues](https://github.com/dotnet/docs/issues) list and volunteer to work on the ones you're interested in:
 
-- Filter by the [good-first-issue](https://github.com/dotnet/docs/labels/good-first-issue) label for, well, good first issues.
-- Filter by the [up-for-grabs](https://github.com/dotnet/docs/labels/up-for-grabs) label for issues appropriate for community contribution. These issues usually require minimal context.
+- Filter by the [good first issue](https://github.com/dotnet/docs/labels/good first issue) label for, well, good first issues.
+- Filter by the [help wanted](https://github.com/dotnet/docs/labels/help wanted) label for issues appropriate for community contribution. These issues usually require minimal context.
 - Experienced contributors can tackle any issues of interest.
 
 When you find an issue to work on, add a comment to ask if it's open.

--- a/Contribute/content/dotnet/dotnet-contribute.md
+++ b/Contribute/content/dotnet/dotnet-contribute.md
@@ -44,7 +44,7 @@ Following these guidelines will ensure a better experience for you and for us.
 Choose an existing issue and address it. You can look at our [open issues](https://github.com/dotnet/docs/issues) list and volunteer to work on the ones you're interested in:
 
 - Filter by the [good first issue](https://github.com/dotnet/docs/labels/good%20first%20issue) label for, well, good first issues.
-- Filter by the [help wanted](https://github.com/dotnet/docs/labels/help wanted) label for issues appropriate for community contribution. These issues usually require minimal context.
+- Filter by the [help wanted](https://github.com/dotnet/docs/labels/help%20wanted) label for issues appropriate for community contribution. These issues usually require minimal context.
 - Experienced contributors can tackle any issues of interest.
 
 When you find an issue to work on, add a comment to ask if it's open.


### PR DESCRIPTION
The labels `good-first-issue` and `up-for-grabs` no longer exist. Instead, `good first issue` and `help wanted` exist.

Live link: https://learn.microsoft.com/en-us/contribute/content/dotnet/dotnet-contribute

<!--
## Quality control

- [x] 1. **Successful build with no warnings or errors**: Review the build status to make sure **all checks are green** (Succeeded).

- [ ] 2. **#Sign-off**: Once the PR is finalized and ready to be merged, indicate so by typing `#sign-off` in a new comment in the PR. Signing off means the document is ready for review and can be published at any time.

If you have an open PR, tag the PR reviewers in a comment with your question: `@carlyrevier, @jehchow`
-->