### PR TITLE
Remove list of OpenSource repos

### DIFF
--- a/Contribute/content/provide-feedback.md
+++ b/Contribute/content/provide-feedback.md
@@ -72,37 +72,6 @@ The open-source feedback experience allows open-source communities to use GitHub
 
 To open a GitHub issue, you must have a GitHub account. For more information, see [Create GitHub issues](how-to-create-github-issues.md).
 
-Currently, the open-source experience is enabled for the following repositories:
-
-- Azure/azure-docs-sdk-dotnet
-- Azure/azure-docs-sdk-java
-- dotnet/AspNetCore.Docs
-- dotnet/docs
-- dotnet/docs-aspire
-- dotnet/docs-desktop
-- dotnet/docs-maui
-- dotnet/entityframework.apidocs
-- dotnet/entityframework.docs
-- dotnet/maui-api-docs
-- MicrosoftDocs/azure-docs-powershell
-- MicrosoftDocs/azure-docs-sdk-node
-- MicrosoftDocs/azure-docs-sdk-python
-- MicrosoftDocs/community-content
-- MicrosoftDocs/microsoft-365-community
-- MicrosoftDocs/PowerShell-Docs
-- MicrosoftDocs/PowerShell-Docs-DSC
-- MicrosoftDocs/PowerShell-Docs-Modules
-- MicrosoftDocs/PowerShell-Docs-PSGet
-- MicrosoftDocs/terminal
-- MicrosoftDocs/Windows-Dev-Docs
-- MicrosoftDocs/WSL
-- Mono/SkiaSharp-API-docs
-- OfficeDev/office-js-docs-pr
-- OfficeDev/office-js-docs-reference
-- OfficeDev/office-scripts-docs
-- OfficeDev/office-scripts-docs-reference
-- Xamarin/essentials
-
 ## Related content
 
 - [Edit documentation in the browser](how-to-write-quick-edits.md)


### PR DESCRIPTION
This PR removes the list of repositories that are configured to use the `OpenSource` user feedback experience. We shouldn't publish a list like this for the following reasons:

- The current list is out of date and it's too hard to maintain the list.
- The configuration is at the docset level not the repo level. A repo can have multiple docsets.
- Within a docset, you can limit the `OpenSource` to specific folders. For example, the **dotnet/docs** repo uses `Standard` feedback for some folders and `OpenSource` for others.
- The customer doesn't know or care about which repos are configured. They only know what they see on the web page.
- If the `OpenSource` feedback control exists on the bottom of the page, then the user can use it. If its not there, then they can't. Knowing the repo name is not helpful.